### PR TITLE
Correct type constraint for attributes of value type flaglist. Issue #12

### DIFF
--- a/lib/Chart/Plotly/Trace/Area.pm
+++ b/lib/Chart/Plotly/Trace/Area.pm
@@ -144,7 +144,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 

--- a/lib/Chart/Plotly/Trace/Bar.pm
+++ b/lib/Chart/Plotly/Trace/Bar.pm
@@ -243,7 +243,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 

--- a/lib/Chart/Plotly/Trace/Barpolar.pm
+++ b/lib/Chart/Plotly/Trace/Barpolar.pm
@@ -194,7 +194,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 

--- a/lib/Chart/Plotly/Trace/Box.pm
+++ b/lib/Chart/Plotly/Trace/Box.pm
@@ -180,7 +180,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 
@@ -214,6 +214,7 @@ Do the hover effects highlight individual boxes  or sample points or both?
 
 has hoveron => (
     is => "rw",
+    isa => "Str",
     documentation => "Do the hover effects highlight individual boxes  or sample points or both?",
 );
 

--- a/lib/Chart/Plotly/Trace/Candlestick.pm
+++ b/lib/Chart/Plotly/Trace/Candlestick.pm
@@ -204,7 +204,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 

--- a/lib/Chart/Plotly/Trace/Carpet.pm
+++ b/lib/Chart/Plotly/Trace/Carpet.pm
@@ -306,7 +306,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 

--- a/lib/Chart/Plotly/Trace/Choropleth.pm
+++ b/lib/Chart/Plotly/Trace/Choropleth.pm
@@ -191,7 +191,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 

--- a/lib/Chart/Plotly/Trace/Cone.pm
+++ b/lib/Chart/Plotly/Trace/Cone.pm
@@ -226,7 +226,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 

--- a/lib/Chart/Plotly/Trace/Contour.pm
+++ b/lib/Chart/Plotly/Trace/Contour.pm
@@ -248,7 +248,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 

--- a/lib/Chart/Plotly/Trace/Contourcarpet.pm
+++ b/lib/Chart/Plotly/Trace/Contourcarpet.pm
@@ -343,7 +343,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 

--- a/lib/Chart/Plotly/Trace/Heatmap.pm
+++ b/lib/Chart/Plotly/Trace/Heatmap.pm
@@ -212,7 +212,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 

--- a/lib/Chart/Plotly/Trace/Heatmapgl.pm
+++ b/lib/Chart/Plotly/Trace/Heatmapgl.pm
@@ -201,7 +201,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 

--- a/lib/Chart/Plotly/Trace/Histogram.pm
+++ b/lib/Chart/Plotly/Trace/Histogram.pm
@@ -229,7 +229,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 

--- a/lib/Chart/Plotly/Trace/Histogram2d.pm
+++ b/lib/Chart/Plotly/Trace/Histogram2d.pm
@@ -228,7 +228,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 

--- a/lib/Chart/Plotly/Trace/Histogram2dcontour.pm
+++ b/lib/Chart/Plotly/Trace/Histogram2dcontour.pm
@@ -252,7 +252,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 

--- a/lib/Chart/Plotly/Trace/Mesh3d.pm
+++ b/lib/Chart/Plotly/Trace/Mesh3d.pm
@@ -296,7 +296,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 

--- a/lib/Chart/Plotly/Trace/Ohlc.pm
+++ b/lib/Chart/Plotly/Trace/Ohlc.pm
@@ -204,7 +204,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 

--- a/lib/Chart/Plotly/Trace/Parcats.pm
+++ b/lib/Chart/Plotly/Trace/Parcats.pm
@@ -191,6 +191,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
+    isa => "Str",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 

--- a/lib/Chart/Plotly/Trace/Parcoords.pm
+++ b/lib/Chart/Plotly/Trace/Parcoords.pm
@@ -168,7 +168,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 

--- a/lib/Chart/Plotly/Trace/Pie.pm
+++ b/lib/Chart/Plotly/Trace/Pie.pm
@@ -195,7 +195,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 
@@ -519,6 +519,7 @@ Determines which trace information appear on the graph.
 
 has textinfo => (
     is => "rw",
+    isa => "Str",
     documentation => "Determines which trace information appear on the graph.",
 );
 

--- a/lib/Chart/Plotly/Trace/Pointcloud.pm
+++ b/lib/Chart/Plotly/Trace/Pointcloud.pm
@@ -143,7 +143,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 

--- a/lib/Chart/Plotly/Trace/Sankey.pm
+++ b/lib/Chart/Plotly/Trace/Sankey.pm
@@ -168,6 +168,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
+    isa => "Str",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired. Note that this attribute is superseded by `node.hoverinfo` and `node.hoverinfo` for nodes and links respectively.",
 );
 

--- a/lib/Chart/Plotly/Trace/Scatter.pm
+++ b/lib/Chart/Plotly/Trace/Scatter.pm
@@ -253,7 +253,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 
@@ -287,6 +287,7 @@ Do the hover effects highlight individual points (markers or line points) or do 
 
 has hoveron => (
     is => "rw",
+    isa => "Str",
     documentation => "Do the hover effects highlight individual points (markers or line points) or do they highlight filled regions? If the fill is *toself* or *tonext* and there are no markers or text, then the default is *fills*, otherwise it is *points*.",
 );
 
@@ -402,6 +403,7 @@ Determines the drawing mode for this scatter trace. If the provided `mode` inclu
 
 has mode => (
     is => "rw",
+    isa => "Str",
     documentation => "Determines the drawing mode for this scatter trace. If the provided `mode` includes *text* then the `text` elements appear at the coordinates. Otherwise, the `text` elements appear on hover. If there are less than 20 points and the trace is not stacked then the default is *lines+markers*. Otherwise, *lines*.",
 );
 

--- a/lib/Chart/Plotly/Trace/Scatter3d.pm
+++ b/lib/Chart/Plotly/Trace/Scatter3d.pm
@@ -192,7 +192,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 
@@ -306,6 +306,7 @@ Determines the drawing mode for this scatter trace. If the provided `mode` inclu
 
 has mode => (
     is => "rw",
+    isa => "Str",
     documentation => "Determines the drawing mode for this scatter trace. If the provided `mode` includes *text* then the `text` elements appear at the coordinates. Otherwise, the `text` elements appear on hover. If there are less than 20 points and the trace is not stacked then the default is *lines+markers*. Otherwise, *lines*.",
 );
 

--- a/lib/Chart/Plotly/Trace/Scattercarpet.pm
+++ b/lib/Chart/Plotly/Trace/Scattercarpet.pm
@@ -243,7 +243,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 
@@ -277,6 +277,7 @@ Do the hover effects highlight individual points (markers or line points) or do 
 
 has hoveron => (
     is => "rw",
+    isa => "Str",
     documentation => "Do the hover effects highlight individual points (markers or line points) or do they highlight filled regions? If the fill is *toself* or *tonext* and there are no markers or text, then the default is *fills*, otherwise it is *points*.",
 );
 
@@ -344,6 +345,7 @@ Determines the drawing mode for this scatter trace. If the provided `mode` inclu
 
 has mode => (
     is => "rw",
+    isa => "Str",
     documentation => "Determines the drawing mode for this scatter trace. If the provided `mode` includes *text* then the `text` elements appear at the coordinates. Otherwise, the `text` elements appear on hover. If there are less than 20 points and the trace is not stacked then the default is *lines+markers*. Otherwise, *lines*.",
 );
 

--- a/lib/Chart/Plotly/Trace/Scattergeo.pm
+++ b/lib/Chart/Plotly/Trace/Scattergeo.pm
@@ -194,7 +194,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 
@@ -392,6 +392,7 @@ Determines the drawing mode for this scatter trace. If the provided `mode` inclu
 
 has mode => (
     is => "rw",
+    isa => "Str",
     documentation => "Determines the drawing mode for this scatter trace. If the provided `mode` includes *text* then the `text` elements appear at the coordinates. Otherwise, the `text` elements appear on hover. If there are less than 20 points and the trace is not stacked then the default is *lines+markers*. Otherwise, *lines*.",
 );
 

--- a/lib/Chart/Plotly/Trace/Scattergl.pm
+++ b/lib/Chart/Plotly/Trace/Scattergl.pm
@@ -229,7 +229,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 
@@ -367,6 +367,7 @@ Determines the drawing mode for this scatter trace.
 
 has mode => (
     is => "rw",
+    isa => "Str",
     documentation => "Determines the drawing mode for this scatter trace.",
 );
 

--- a/lib/Chart/Plotly/Trace/Scattermapbox.pm
+++ b/lib/Chart/Plotly/Trace/Scattermapbox.pm
@@ -183,7 +183,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 
@@ -345,6 +345,7 @@ Determines the drawing mode for this scatter trace. If the provided `mode` inclu
 
 has mode => (
     is => "rw",
+    isa => "Str",
     documentation => "Determines the drawing mode for this scatter trace. If the provided `mode` includes *text* then the `text` elements appear at the coordinates. Otherwise, the `text` elements appear on hover.",
 );
 

--- a/lib/Chart/Plotly/Trace/Scatterpolar.pm
+++ b/lib/Chart/Plotly/Trace/Scatterpolar.pm
@@ -219,7 +219,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 
@@ -253,6 +253,7 @@ Do the hover effects highlight individual points (markers or line points) or do 
 
 has hoveron => (
     is => "rw",
+    isa => "Str",
     documentation => "Do the hover effects highlight individual points (markers or line points) or do they highlight filled regions? If the fill is *toself* or *tonext* and there are no markers or text, then the default is *fills*, otherwise it is *points*.",
 );
 
@@ -344,6 +345,7 @@ Determines the drawing mode for this scatter trace. If the provided `mode` inclu
 
 has mode => (
     is => "rw",
+    isa => "Str",
     documentation => "Determines the drawing mode for this scatter trace. If the provided `mode` includes *text* then the `text` elements appear at the coordinates. Otherwise, the `text` elements appear on hover. If there are less than 20 points and the trace is not stacked then the default is *lines+markers*. Otherwise, *lines*.",
 );
 

--- a/lib/Chart/Plotly/Trace/Scatterpolargl.pm
+++ b/lib/Chart/Plotly/Trace/Scatterpolargl.pm
@@ -207,7 +207,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 
@@ -321,6 +321,7 @@ Determines the drawing mode for this scatter trace. If the provided `mode` inclu
 
 has mode => (
     is => "rw",
+    isa => "Str",
     documentation => "Determines the drawing mode for this scatter trace. If the provided `mode` includes *text* then the `text` elements appear at the coordinates. Otherwise, the `text` elements appear on hover. If there are less than 20 points and the trace is not stacked then the default is *lines+markers*. Otherwise, *lines*.",
 );
 

--- a/lib/Chart/Plotly/Trace/Scatterternary.pm
+++ b/lib/Chart/Plotly/Trace/Scatterternary.pm
@@ -267,7 +267,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 
@@ -301,6 +301,7 @@ Do the hover effects highlight individual points (markers or line points) or do 
 
 has hoveron => (
     is => "rw",
+    isa => "Str",
     documentation => "Do the hover effects highlight individual points (markers or line points) or do they highlight filled regions? If the fill is *toself* or *tonext* and there are no markers or text, then the default is *fills*, otherwise it is *points*.",
 );
 
@@ -392,6 +393,7 @@ Determines the drawing mode for this scatter trace. If the provided `mode` inclu
 
 has mode => (
     is => "rw",
+    isa => "Str",
     documentation => "Determines the drawing mode for this scatter trace. If the provided `mode` includes *text* then the `text` elements appear at the coordinates. Otherwise, the `text` elements appear on hover. If there are less than 20 points and the trace is not stacked then the default is *lines+markers*. Otherwise, *lines*.",
 );
 

--- a/lib/Chart/Plotly/Trace/Splom.pm
+++ b/lib/Chart/Plotly/Trace/Splom.pm
@@ -168,7 +168,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 

--- a/lib/Chart/Plotly/Trace/Streamtube.pm
+++ b/lib/Chart/Plotly/Trace/Streamtube.pm
@@ -215,7 +215,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 

--- a/lib/Chart/Plotly/Trace/Surface.pm
+++ b/lib/Chart/Plotly/Trace/Surface.pm
@@ -237,7 +237,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 

--- a/lib/Chart/Plotly/Trace/Table.pm
+++ b/lib/Chart/Plotly/Trace/Table.pm
@@ -223,7 +223,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 

--- a/lib/Chart/Plotly/Trace/Violin.pm
+++ b/lib/Chart/Plotly/Trace/Violin.pm
@@ -182,7 +182,7 @@ Determines which trace information appear on hover. If `none` or `skip` are set,
 
 has hoverinfo => (
     is => "rw",
-    isa => "Maybe[ArrayRef]",
+    isa => "Str|ArrayRef[Str]",
     documentation => "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
 );
 
@@ -216,6 +216,7 @@ Do the hover effects highlight individual violins or sample points or the kernel
 
 has hoveron => (
     is => "rw",
+    isa => "Str",
     documentation => "Do the hover effects highlight individual violins or sample points or the kernel density estimate or any combination of them?",
 );
 

--- a/tool/generate_from_schema.pl
+++ b/tool/generate_from_schema.pl
@@ -15,7 +15,7 @@ use Scalar::Util;
 
 # TODO Use enum names
 # TODO Use enums with JSON::false and JSON::true and number
-# TODO Types: color, subplotid, flaglist, angle, colorscale
+# TODO Types: color, subplotid, angle, colorscale
 # TODO Add defaults?
 # TODO Add support for items
 
@@ -23,6 +23,7 @@ my $moose_type_for = {
     any        => 'Any',
     number     => 'Num',
     string     => 'Str',
+    flaglist   => 'Str',
     boolean    => 'Bool',
     integer    => 'Int',
     info_array => 'ArrayRef|PDL',


### PR DESCRIPTION
Type constraint for attributes of value type `flaglist` were not generated correctly because this value type was ignored and the type constraint only used the `arrayOk` part of the value type (hence the reported wrong constraint `Maybe[ArrayRef] #12 )

