### PR TITLE
support Alien::Plotly::Orca

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -42,6 +42,8 @@ location = root
 [PodSyntaxTests] 
 [PodCoverageTests]
 [AutoPrereqs]
+; don't want Alien::Plotly::Orca be in runtime-"requires"
+skip = ^Alien::Plotly::Orca$
 [PerlTidy]
 perltidyrc = .perltidyrc
 [Test::Perl::Critic]

--- a/t/20-orca.t
+++ b/t/20-orca.t
@@ -6,6 +6,7 @@ use utf8;
 
 use Path::Tiny;
 use Test::More;
+use Test::File::ShareDir -share => { -dist => { 'Chart-Plotly' => 'share' } };
 
 use Chart::Plotly::Plot;
 use Chart::Plotly::Trace::Scatter;

--- a/t/20-orca.t
+++ b/t/20-orca.t
@@ -1,0 +1,38 @@
+#!/usr/bin/env perl -w
+
+use strict;
+use warnings;
+use utf8;
+
+use Path::Tiny;
+use Test::More;
+
+use Chart::Plotly::Plot;
+use Chart::Plotly::Trace::Scatter;
+
+BEGIN {
+    use_ok('Chart::Plotly::Image::Orca');
+}
+
+SKIP: {
+    my $has_orca = Chart::Plotly::Image::Orca::_check_alien();
+    skip( "Have not Alien::Plotly::Orca", 2 ) unless $has_orca;
+
+    diag("Found Alien::Plotly::Orca");
+    ok( Chart::Plotly::Image::Orca::orca_available(), "orca_available()" );
+    like( Chart::Plotly::Image::Orca::orca_version(), qr/^\d+/, "orca_version()" );
+
+    # try create an image
+    my $x       = [ 1 .. 15 ];
+    my $y       = [ map { rand 10 } @$x ];
+    my $scatter = Chart::Plotly::Trace::Scatter->new( x => $x, y => $y );
+    my $plot    = Chart::Plotly::Plot->new();
+    $plot->add_trace($scatter);
+
+    my $tempfile = Path::Tiny->tempfile( SUFFIX => '.png' );
+    Chart::Plotly::Image::Orca::orca( plot => $plot, file => $tempfile );
+    my $size = ( stat($tempfile) )[7];
+    ok( $size > 0, 'orca()' );
+}
+
+done_testing;


### PR DESCRIPTION
Today I released Alien::Plotly::Orca https://metacpan.org/pod/Alien::Plotly::Orca. And this is basic changes to support Alien::Plotly::Orca. As orca may not work on some OS plaltforms or in some condtions, I don't want Alien::Plotly::Orca a runtime-"requires" of Chart::Plotly, instead we can just suggest user install it from CPAN in our error message.  

I will still get some time later this week to look at the local plotly.js thing, and after that I will probably get back to get orca() to support local plotly.js. 