### PR TITLE
Change dependency from configure to develop

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,4 @@
+  - Fix configure dependencies
 0.023 2019-01-20 22:00:00+0000
   - Update to plotly.js 1.43.1
   - Several improvements to Chart::Plotly::Image::Orca

--- a/dist.ini
+++ b/dist.ini
@@ -51,12 +51,12 @@ perltidyrc = .perltidyrc
 [Prereqs / TestRequires]
 Test::Most = 0 ; for done_testing
 [Prereqs / ConfigureRequires]
-Getopt::Long::Descriptive = 0
 Const::Fast = 0
 Path::Tiny = 0 
 Text::Template = 0
 Data::Dump = 0
 [Prereqs / DevelopRequires]
+Getopt::Long::Descriptive = 0
 Pod::Weaver = 0
 Pod::Weaver::Section::Contributors = 0
 


### PR DESCRIPTION
Eliminate the need of Getopt::Long::Descriptive, needed only during development.

Fixes issue #19 