### PR TITLE
Add method from_json to deserialize from json dumps

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,4 @@
+  - Add method Chart::Plotly::Plot->from_json to deserialize from json dumps (useful for dumps from another languages) 
   - Add support for config options
 0.026 2019-06-03 22:00:00+0000 
   - Update to plotly.js 1.48.1

--- a/lib/Chart/Plotly/Plot.pm
+++ b/lib/Chart/Plotly/Plot.pm
@@ -1,7 +1,7 @@
 package Chart::Plotly::Plot;
 
 use Moose;
-use JSON;
+use JSON qw();
 use utf8;
 
 use UUID::Tiny ':std';
@@ -53,7 +53,6 @@ Configuration options for the plot. See L<https://plot.ly/javascript/configurati
 =cut
 
 has config => (
-    default => sub { { responsive => JSON::true } },
     is => 'rw',
     isa => 'HashRef'
 );
@@ -109,6 +108,23 @@ sub TO_JSON {
         $json .= ', "config": ' .  $config;
     }
     return $json . " }";
+}
+
+=head2 from_json
+
+
+
+=cut
+
+sub from_json {
+    my $class = shift;
+    my $json = shift;
+    my $data = JSON::from_json($json);
+    return $class->new(
+        (defined $data->{"data"} ? (traces => $data->{"data"}) : ()),
+        (defined $data->{"layout"} ? (layout => $data->{"layout"}) : ()),
+        (defined $data->{"config"} ? (config => $data->{"config"}) : ())
+    );
 }
 
 1;

--- a/t/60-serialize_json.t
+++ b/t/60-serialize_json.t
@@ -1,0 +1,82 @@
+#!/usr/bin/env perl -w
+
+use strict;
+use warnings;
+use utf8;
+use JSON;
+
+use Test::More tests => 12;
+
+use Chart::Plotly::Plot;
+
+sub GeneratePlotAndComparePlotAndJSON {
+    my $json = shift;
+
+    my $plot = Chart::Plotly::Plot->from_json($json);
+
+    my $perl_hash_from_json = from_json($json);
+
+    is_deeply( $perl_hash_from_json->{"data"},   $plot->traces );
+    is_deeply( $perl_hash_from_json->{"layout"}, $plot->layout );
+    is_deeply( $perl_hash_from_json->{"config"}, $plot->config );
+
+    is_deeply( $perl_hash_from_json, from_json( $plot->TO_JSON ) )
+      ;    # comparing perl objects to avoid the whitespace management
+}
+
+
+{
+    my $simple_json = <<'ENDOFJSON';
+{
+    "data": [{
+         "type": "scatter",
+         "x": [1, 2, 3],
+         "y": [1, 2, 3]
+        }],
+    "layout": {
+
+        },
+    "config": {
+
+        }
+}
+ENDOFJSON
+
+    GeneratePlotAndComparePlotAndJSON($simple_json);
+}
+
+{
+    my $json_without_config = <<'ENDOFJSON';
+{
+    "data": [{
+         "type": "scatter",
+         "x": [1, 2, 3],
+         "y": [1, 2, 3]
+        }],
+    "layout": {
+        "title": {
+                "text": "sample title"
+            }
+        }
+}
+ENDOFJSON
+
+    GeneratePlotAndComparePlotAndJSON($json_without_config);
+}
+
+{
+     my $json_without_layout = <<'ENDOFJSON';
+{
+    "data": [{
+         "type": "scatter",
+         "x": [1, 2, 3],
+         "y": [1, 2, 3]
+        }],
+    "config": {
+         "responsive": true  
+        }
+}
+ENDOFJSON
+
+    GeneratePlotAndComparePlotAndJSON($json_without_layout);
+}


### PR DESCRIPTION
Add method to support deserialization from json dumps. This eases the interoperability with other languages (Julia, Javascript, R, Python, ...) using `Chart::Plotly::Plot->from_json` and `Chart::Plotly::Plot->TO_JSON`.
For example, dumping a plot to JSON from Julia and loading to Perl using this.

Suggested by Eric Smith! Thanks!