### PR TITLE
Use long options to check if orca is the correct orca

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,4 @@
+  - Change orca correct check to use long options (the orca docker container doesn't support -h) 
   - Update to plotly.js 1.51.2
 0.031 2019-11-24 20:00:00+0000  
   - Add information functions about plotly.js use

--- a/lib/Chart/Plotly/Image/Orca.pm
+++ b/lib/Chart/Plotly/Image/Orca.pm
@@ -187,7 +187,7 @@ L<https://help.gnome.org/users/orca/stable/>
 =cut
 
 sub correct_orca {
-    my $orca_help = `$ORCA_COMMAND -h`;
+    my $orca_help = `$ORCA_COMMAND --help`;
     return ($orca_help =~ /plotly/i);
 }
 


### PR DESCRIPTION
Using [official orca container](https://quay.io/repository/plotly/orca) the function to check that the orca is the plotly version `correct_orca()` doesn't work because the container fail to parse the `-h` command line option. Using `--help` works fine.