### PR TITLE
Integrate Devel::IPerl::Plugin::Chart::Plotly

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,4 @@
+  - Integrate Devel::IPerl::Plugin in this package 
 0.032 2019-11-27 20:00:00+0000  
   - Change orca correct check to use long options (the orca docker container doesn't support -h) 
   - Update to plotly.js 1.51.2

--- a/README.md
+++ b/README.md
@@ -140,5 +140,6 @@ The MIT (X11) License
 
 # CONTRIBUTORS
 
+- Roy Storey <kiwiroy@users.noreply.github.com>
 - stphnlyd <stephanloyd9@gmail.com>
 - weatherwax <s.g.lobo@hotmail.com>

--- a/examples/jupyter-notebooks/BasicUse.ipynb
+++ b/examples/jupyter-notebooks/BasicUse.ipynb
@@ -1,0 +1,156 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Devel::IPerl::Plugin::Chart::Plotly demo notebook\n",
+    "==========================\n",
+    "\n",
+    "This notebook is just a demo extracted from the synopsis of [Devel::IPerl::Plugin::Chart::Plotly](https://metacpan.org/pod/Devel::IPerl::Plugin::Chart::Plotly)\n",
+    "\n",
+    "Installing the plugin\n",
+    "------------------\n",
+    "\n",
+    "First you need to install the plugin, so in your shell:\n",
+    "```bash\n",
+    "cpanm Devel::IPerl::Plugin::Chart::Plotly\n",
+    "```\n",
+    "\n",
+    "Using the plugin\n",
+    "------------------\n",
+    "\n",
+    "Just load the plugin:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "IPerl->load_plugin('Chart::Plotly');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once loaded your `Chart::Plotly::Plot` and `Chart::Plotly::Trace` objects will get displayed automatically"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<script>\n",
+       "//# sourceURL=iperl-devel-plugin-chart-plotly.js\n",
+       "            $('#Plotly').each(function(i, e) { $(e).attr('id', 'plotly') });\n",
+       "\n",
+       "            if (!window.Plotly) {\n",
+       "                requirejs.config({\n",
+       "                  paths: {\n",
+       "                    plotly: ['https://cdn.plot.ly/plotly-latest.min']},\n",
+       "                });\n",
+       "                window.Plotly = {\n",
+       "                  plot : function(div, data, layout) {\n",
+       "                    require(['plotly'], function(plotly) {\n",
+       "                      window.Plotly=plotly;\n",
+       "                      Plotly.plot(div, data, layout);\n",
+       "                    });\n",
+       "                  }\n",
+       "                }\n",
+       "            }\n",
+       "</script>\n",
+       "<div id=\"1a62adfa-3b4c-11e8-a0ab-c664e52612d7\"></div>\n",
+       "\n",
+       "<script>\n",
+       "Plotly.plot(document.getElementById('1a62adfa-3b4c-11e8-a0ab-c664e52612d7'),[{\"x\":[1,2,3,4,5],\"y\":[1,2,3,4,5],\"type\":\"scatter\"}] );\n",
+       "</script>\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "use Chart::Plotly::Trace::Scatter;\n",
+    "my $scatter_trace = Chart::Plotly::Trace::Scatter->new( x => [ 1 .. 5 ], y => [ 1 .. 5 ] );"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Also plot objects"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<script>\n",
+       "//# sourceURL=iperl-devel-plugin-chart-plotly.js\n",
+       "            $('#Plotly').each(function(i, e) { $(e).attr('id', 'plotly') });\n",
+       "\n",
+       "            if (!window.Plotly) {\n",
+       "                requirejs.config({\n",
+       "                  paths: {\n",
+       "                    plotly: ['https://cdn.plot.ly/plotly-latest.min']},\n",
+       "                });\n",
+       "                window.Plotly = {\n",
+       "                  plot : function(div, data, layout) {\n",
+       "                    require(['plotly'], function(plotly) {\n",
+       "                      window.Plotly=plotly;\n",
+       "                      Plotly.plot(div, data, layout);\n",
+       "                    });\n",
+       "                  }\n",
+       "                }\n",
+       "            }\n",
+       "</script>\n",
+       "<div id=\"1cad02cc-3b4c-11e8-a0ab-b0096d0108df\"></div>\n",
+       "\n",
+       "<script>\n",
+       "Plotly.plot(document.getElementById('1cad02cc-3b4c-11e8-a0ab-b0096d0108df'),[{\"type\":\"box\",\"x\":[1,1,1,1,1,1,2,2,2,2,2,3,3,3,3,3],\"y\":[0.0821805792172547,0.806485478111895,0.0472466704088639,0.757669784118541,0.36313603881587,0.54215512285171,0.815206321991536,0.547532523620028,0.511531196239634,0.730444433199679,0.837433650463392,0.297000729792579,0.99875796155354,0.91129723013097,0.580636740265486,0.474324525579767],\"name\":\"box1\"},{\"name\":\"box2\",\"x\":[1,1,1,1,1,1,2,2,2,2,2,3,3,3,3,3],\"y\":[0.970445049360524,0.353943440982292,0.420845074138523,0.345593698371822,0.766164635026488,0.796270891865191,0.284695247816227,0.312673856434976,0.365783887504637,0.816166566884803,0.268062821884737,0.543521621886576,0.682022049611792,0.236740261791624,0.361228133149933,0.492830987672598],\"type\":\"box\"}] ,{\"boxmode\":\"group\"});\n",
+       "</script>\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "use Chart::Plotly::Trace::Box;\n",
+    "use Chart::Plotly::Plot;\n",
+    " \n",
+    "my $x = [ 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3 ];\n",
+    "my $box1 = Chart::Plotly::Trace::Box->new( x => $x, y => [ map { rand() } ( 1 .. ( scalar(@$x) ) ) ], name => \"box1\" );\n",
+    "my $box2 = Chart::Plotly::Trace::Box->new( x => $x, y => [ map { rand() } ( 1 .. ( scalar(@$x) ) ) ], name => \"box2\" );\n",
+    "my $plot = Chart::Plotly::Plot->new( traces => [ $box1, $box2 ], layout => { boxmode => 'group' } );"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "IPerl 0.009",
+   "language": "perl",
+   "name": "iperl"
+  },
+  "language_info": {
+   "file_extension": ".pl",
+   "mimetype": "text/x-perl",
+   "name": "perl",
+   "version": "5.22.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/lib/Devel/IPerl/Plugin/Chart/Plotly.pm
+++ b/lib/Devel/IPerl/Plugin/Chart/Plotly.pm
@@ -1,0 +1,94 @@
+package Devel::IPerl::Plugin::Chart::Plotly;
+
+use 5.022001;
+
+use strict;
+use warnings;
+use utf8;
+
+use English qw(-no_match_vars);
+use Const::Fast;
+use namespace::autoclean;
+
+
+# VERSION
+
+# ABSTRACT: Inline display of plotly charts in Jupyter notebooks using L<Devel::IPerl> kernel
+
+
+=encoding utf8
+
+=head1 SYNOPSIS
+
+    # In notebook
+    IPerl->load_plugin('Chart::Plotly');
+
+    use Chart::Plotly::Trace::Scatter;
+    use Chart::Plotly::Plot;
+    my $scatter_trace = Chart::Plotly::Trace::Scatter->new( x => [ 1 .. 5 ], y => [ 1 .. 5 ] );
+    my $plot = Chart::Plotly::Plot->new(traces => [$scatter_trace]);
+
+=head1 DESCRIPTION
+
+Plugin to display automatically L<Chart::Plotly> plot objects in Jupyter notebooks using kernel L<Devel::IPerl>
+
+=head1 INSTANCE METHODS
+
+=cut
+
+=head2 register
+
+This method is called automatically by L<Devel::IPerl>. You only need to load the plugin:
+
+    IPerl->load_plugin('Chart::Plotly');
+
+=cut
+
+sub register {
+	# only works registering the plugin for each notebook
+	require Chart::Plotly::Plot;
+	require Role::Tiny;
+
+	Role::Tiny->apply_roles_to_package( 'Chart::Plotly::Plot', q(Devel::IPerl::Plugin::Chart::Plotly::Plot::IPerlRole) );
+}
+
+
+{
+package
+	Devel::IPerl::Plugin::Chart::Plotly::Plot::IPerlRole;
+
+use Moo::Role;
+
+use Devel::IPerl::Display::HTML;
+
+sub iperl_data_representations {
+	my ($plot) = @_;
+    my $require_plotly = '
+<script>
+            if(!window.Plotly) {
+                requirejs.config({
+                    paths: { 
+                    \'plotly\': [\'https://cdn.plot.ly/plotly-latest.min\']},
+                });
+                window.Plotly = {
+                    "plot" : function(div, data, layout) {
+                    require([\'plotly\'],
+                    function(plotly) {window.Plotly=plotly;
+                        Plotly.plot(div, data, layout);
+                        });
+                    }
+                }
+            }
+</script>
+';
+    Devel::IPerl::Display::HTML->new($require_plotly . $plot->html)->iperl_data_representations;
+}
+
+}
+
+=head1 CLASS METHODS
+
+=cut
+
+1; 
+

--- a/lib/Devel/IPerl/Plugin/Chart/Plotly.pm
+++ b/lib/Devel/IPerl/Plugin/Chart/Plotly.pm
@@ -35,6 +35,8 @@ use namespace::autoclean;
 
 Plugin to display automatically L<Chart::Plotly> plot objects in Jupyter notebooks using kernel L<Devel::IPerl>
 
+The example above can be viewed in L<nbviewer|http://nbviewer.jupyter.org/github/pablrod/p5-Devel-IPerl-Plugin-Chart-Plotly/blob/master/examples/PlotlyPlugin.ipynb>
+
 =head1 INSTANCE METHODS
 
 =cut

--- a/lib/Devel/IPerl/Plugin/Chart/Plotly.pm
+++ b/lib/Devel/IPerl/Plugin/Chart/Plotly.pm
@@ -39,24 +39,27 @@ Plugin to display automatically L<Chart::Plotly> plot objects in Jupyter noteboo
 
 =cut
 
-my $require_plotly = '
+my $require_plotly = <<'EOJS';
 <script>
-            if(!window.Plotly) {
+//@ sourceURL=iperl-devel-plugin-chart-plotly.js
+            $('#Plotly').each(function(i, e) { $(e).attr('id', 'plotly') });
+
+            if (!window.Plotly) {
                 requirejs.config({
-                    paths: { 
-                    \'plotly\': [\'https://cdn.plot.ly/plotly-latest.min\']},
+                  paths: {
+                    plotly: ['https://cdn.plot.ly/plotly-latest.min']},
                 });
                 window.Plotly = {
-                    "plot" : function(div, data, layout) {
-                    require([\'plotly\'],
-                    function(plotly) {window.Plotly=plotly;
-                        Plotly.plot(div, data, layout);
-                        });
-                    }
+                  plot : function(div, data, layout) {
+                    require(['plotly'], function(plotly) {
+                      window.Plotly=plotly;
+                      Plotly.plot(div, data, layout);
+                    });
+                  }
                 }
             }
 </script>
-';
+EOJS
 
 
 =head2 register
@@ -105,11 +108,10 @@ use Devel::IPerl::Display::HTML;
 sub iperl_data_representations {
     require Chart::Plotly::Plot;
 	my ($trace) = @_;
-    my $plot = Chart::Plotly::Plot->new(traces => [$trace]); 
+    my $plot = Chart::Plotly::Plot->new(traces => [$trace]);
     Devel::IPerl::Display::HTML->new($require_plotly . $plot->html)->iperl_data_representations;
 }
 
 }
 
-1; 
-
+1;

--- a/lib/Devel/IPerl/Plugin/Chart/Plotly.pm
+++ b/lib/Devel/IPerl/Plugin/Chart/Plotly.pm
@@ -7,7 +7,7 @@ use warnings;
 use utf8;
 
 use English qw(-no_match_vars);
-use Const::Fast;
+use Module::Find;
 use namespace::autoclean;
 
 
@@ -23,10 +23,18 @@ use namespace::autoclean;
     # In notebook
     IPerl->load_plugin('Chart::Plotly');
 
+    # Trace objects get displayed automatically
     use Chart::Plotly::Trace::Scatter;
-    use Chart::Plotly::Plot;
     my $scatter_trace = Chart::Plotly::Trace::Scatter->new( x => [ 1 .. 5 ], y => [ 1 .. 5 ] );
-    my $plot = Chart::Plotly::Plot->new(traces => [$scatter_trace]);
+
+    # Also Plot objects
+    use Chart::Plotly::Trace::Box;
+    use Chart::Plotly::Plot;
+
+    my $x = [ 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3 ];
+    my $box1 = Chart::Plotly::Trace::Box->new( x => $x, y => [ map { rand() } ( 1 .. ( scalar(@$x) ) ) ], name => "box1" );
+    my $box2 = Chart::Plotly::Trace::Box->new( x => $x, y => [ map { rand() } ( 1 .. ( scalar(@$x) ) ) ], name => "box2" );
+    my $plot = Chart::Plotly::Plot->new( traces => [ $box1, $box2 ], layout => { boxmode => 'group' } );
 
 =head1 DESCRIPTION
 
@@ -36,34 +44,7 @@ Plugin to display automatically L<Chart::Plotly> plot objects in Jupyter noteboo
 
 =cut
 
-=head2 register
-
-This method is called automatically by L<Devel::IPerl>. You only need to load the plugin:
-
-    IPerl->load_plugin('Chart::Plotly');
-
-=cut
-
-sub register {
-	# only works registering the plugin for each notebook
-	require Chart::Plotly::Plot;
-	require Role::Tiny;
-
-	Role::Tiny->apply_roles_to_package( 'Chart::Plotly::Plot', q(Devel::IPerl::Plugin::Chart::Plotly::Plot::IPerlRole) );
-}
-
-
-{
-package
-	Devel::IPerl::Plugin::Chart::Plotly::Plot::IPerlRole;
-
-use Moo::Role;
-
-use Devel::IPerl::Display::HTML;
-
-sub iperl_data_representations {
-	my ($plot) = @_;
-    my $require_plotly = '
+my $require_plotly = '
 <script>
             if(!window.Plotly) {
                 requirejs.config({
@@ -81,6 +62,55 @@ sub iperl_data_representations {
             }
 </script>
 ';
+
+
+=head2 register
+
+This method is called automatically by L<Devel::IPerl>. You only need to load the plugin:
+
+    IPerl->load_plugin('Chart::Plotly');
+
+=cut
+
+sub register {
+	# only works registering the plugin for each notebook
+	require Chart::Plotly::Plot;
+	require Role::Tiny;
+
+	Role::Tiny->apply_roles_to_package( 'Chart::Plotly::Plot', q(Devel::IPerl::Plugin::Chart::Plotly::Plot::IPerlRole) );
+    for my $module (findsubmod('Chart::Plotly::Trace')) {
+	    Role::Tiny->apply_roles_to_package( $module, q(Devel::IPerl::Plugin::Chart::Plotly::Plot::Trace::IPerlRole) );
+    }
+}
+
+
+{
+package
+	Devel::IPerl::Plugin::Chart::Plotly::Plot::IPerlRole;
+
+use Moo::Role;
+
+use Devel::IPerl::Display::HTML;
+
+sub iperl_data_representations {
+	my ($plot) = @_;
+    Devel::IPerl::Display::HTML->new($require_plotly . $plot->html)->iperl_data_representations;
+}
+
+}
+
+{
+package
+	Devel::IPerl::Plugin::Chart::Plotly::Plot::Trace::IPerlRole;
+
+use Moo::Role;
+
+use Devel::IPerl::Display::HTML;
+
+sub iperl_data_representations {
+    require Chart::Plotly::Plot;
+	my ($trace) = @_;
+    my $plot = Chart::Plotly::Plot->new(traces => [$trace]); 
     Devel::IPerl::Display::HTML->new($require_plotly . $plot->html)->iperl_data_representations;
 }
 

--- a/lib/Devel/IPerl/Plugin/Chart/Plotly.pm
+++ b/lib/Devel/IPerl/Plugin/Chart/Plotly.pm
@@ -92,7 +92,7 @@ use Devel::IPerl::Display::HTML;
 
 sub iperl_data_representations {
 	my ($plot) = @_;
-    Devel::IPerl::Display::HTML->new($require_plotly . $plot->html)->iperl_data_representations;
+    Devel::IPerl::Display::HTML->new($require_plotly . $plot->html(load_plotly_using_script_tag => 0))->iperl_data_representations;
 }
 
 }
@@ -109,7 +109,7 @@ sub iperl_data_representations {
     require Chart::Plotly::Plot;
 	my ($trace) = @_;
     my $plot = Chart::Plotly::Plot->new(traces => [$trace]);
-    Devel::IPerl::Display::HTML->new($require_plotly . $plot->html)->iperl_data_representations;
+    Devel::IPerl::Display::HTML->new($require_plotly . $plot->html(load_plotly_using_script_tag => 0))->iperl_data_representations;
 }
 
 }

--- a/lib/Devel/IPerl/Plugin/Chart/Plotly.pm
+++ b/lib/Devel/IPerl/Plugin/Chart/Plotly.pm
@@ -41,7 +41,7 @@ Plugin to display automatically L<Chart::Plotly> plot objects in Jupyter noteboo
 
 my $require_plotly = <<'EOJS';
 <script>
-//@ sourceURL=iperl-devel-plugin-chart-plotly.js
+//# sourceURL=iperl-devel-plugin-chart-plotly.js
             $('#Plotly').each(function(i, e) { $(e).attr('id', 'plotly') });
 
             if (!window.Plotly) {

--- a/lib/Devel/IPerl/Plugin/Chart/Plotly.pm
+++ b/lib/Devel/IPerl/Plugin/Chart/Plotly.pm
@@ -1,20 +1,15 @@
 package Devel::IPerl::Plugin::Chart::Plotly;
 
-use 5.022001;
-
 use strict;
 use warnings;
 use utf8;
 
-use English qw(-no_match_vars);
 use Module::Find;
 use namespace::autoclean;
-
 
 # VERSION
 
 # ABSTRACT: Inline display of plotly charts in Jupyter notebooks using L<Devel::IPerl> kernel
-
 
 =encoding utf8
 
@@ -115,10 +110,6 @@ sub iperl_data_representations {
 }
 
 }
-
-=head1 CLASS METHODS
-
-=cut
 
 1; 
 

--- a/lib/Devel/IPerl/Plugin/Chart/Plotly.pm
+++ b/lib/Devel/IPerl/Plugin/Chart/Plotly.pm
@@ -5,6 +5,7 @@ use warnings;
 use utf8;
 
 use Module::Find;
+use Chart::Plotly;
 use namespace::autoclean;
 
 # VERSION
@@ -41,7 +42,8 @@ The example above can be viewed in L<nbviewer|http://nbviewer.jupyter.org/github
 
 =cut
 
-my $require_plotly = <<'EOJS';
+my $parameter_list = "(" . join(", ", Chart::Plotly::plotlyjs_plot_function_parameters()) . ")";
+my $require_plotly = <<'EOJSFP';
 <script>
 //# sourceURL=iperl-devel-plugin-chart-plotly.js
             $('#Plotly').each(function(i, e) { $(e).attr('id', 'plotly') });
@@ -52,17 +54,21 @@ my $require_plotly = <<'EOJS';
                     plotly: ['https://cdn.plot.ly/plotly-latest.min']},
                 });
                 window.Plotly = {
-                  plot : function(div, data, layout) {
+EOJSFP
+
+$require_plotly .= Chart::Plotly::plotlyjs_plot_function() . " : function " . $parameter_list . "{\n";
+$require_plotly .= <<'EOJSSP';
                     require(['plotly'], function(plotly) {
                       window.Plotly=plotly;
-                      Plotly.plot(div, data, layout);
+EOJSSP
+$require_plotly .= "Plotly." . Chart::Plotly::plotlyjs_plot_function() . $parameter_list . ";";
+$require_plotly .= <<'EOJSTP';
                     });
                   }
                 }
             }
 </script>
-EOJS
-
+EOJSTP
 
 =head2 register
 

--- a/t/Devel-IPerl-Plugin/00-load-devel_iperl_plugin.t
+++ b/t/Devel-IPerl-Plugin/00-load-devel_iperl_plugin.t
@@ -1,0 +1,9 @@
+use strict;
+use warnings;
+
+use Test::More tests => 1;
+
+use_ok('Devel::IPerl::Plugin::Chart::Plotly');
+
+
+

--- a/t/Devel-IPerl-Plugin/01-basic-use.t
+++ b/t/Devel-IPerl-Plugin/01-basic-use.t
@@ -1,0 +1,14 @@
+
+use strict;
+use warnings;
+
+use Test::More tests => 2;
+
+use Devel::IPerl::Plugin::Chart::Plotly;
+
+Devel::IPerl::Plugin::Chart::Plotly->register();
+
+ok(Chart::Plotly::Plot->can('iperl_data_representations'));
+ok(Chart::Plotly::Trace::Scatter->can('iperl_data_representations'));
+
+


### PR DESCRIPTION
This pull request tries to make easier for users use Chart::Plotly with Jupyter Notebooks. 

As discussed in https://github.com/pablrod/p5-Devel-IPerl-Plugin-Chart-Plotly/issues/4 users expects this functionality shipped with Chart::Plotly itself. It's the same that the Python plugin does.