### PR TITLE
Fix TO_JSON should return structure not a string

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,4 @@
+  - TO_JSON returns a structure, for text use to_json_text
 0.037 2020-01-14 12:00:00+0000  
   - Update to plotly.js v1.52.1
 0.036 2020-01-13 10:00:00+0000  

--- a/lib/Chart/Plotly/Plot.pm
+++ b/lib/Chart/Plotly/Plot.pm
@@ -99,11 +99,39 @@ sub html {
 
 =head2 TO_JSON
 
-Returns the json corresponding to the plot
+Returns the structure suitable to serialize to JSON corresponding to the plot.
+
+This method is meant to be called by a JSON serializer, not directly.
+
+Beware with nested data. For example piddle are still there and you're
+responsible to provide an appropiatte serializer. If you want
+the text representation of json use the method: to_json_text
 
 =cut
 
 sub TO_JSON {
+    my $self   = shift;
+    my $layout = $self->layout;
+    my $config = $self->config;
+    my %json   = ( data => $self->traces() );
+    if ( defined $layout ) {
+        $json{layout} = $layout;
+    }
+    if ( defined $config ) {
+        $json{config} = $config;
+    }
+    return \%json;
+}
+
+
+=head2 to_json_text
+
+Returns the plot serialized in JSON. Not suitable to use in 
+nested structures. For nested structures you should check TO_JSON
+
+=cut
+
+sub to_json_text {
     my $self     = shift;
     my $layout = $self->layout;
     my $config = $self->config;
@@ -122,7 +150,13 @@ sub TO_JSON {
 
 =head2 from_json
 
+Build the plot from a json string in the format returned by to_json_text.
 
+Beware when using to_json_text and from_json the plot object can be
+slightly different (although the representation is the same). That is the
+reconstructed plot is equivalent to the first, for example when using PDL, 
+piddles are serialized to simple arrays and when deserialized are just plain
+arrays.
 
 =cut
 

--- a/t/50-config_support.t
+++ b/t/50-config_support.t
@@ -15,7 +15,7 @@ my $plot_with_config = Chart::Plotly::Plot->new(config => $config);
 
 is_deeply($plot_with_config->config, $config, 'Plot objects support config options');
 
-my $hash_from_plot = from_json($plot_with_config->TO_JSON());
+my $hash_from_plot = from_json($plot_with_config->to_json_text());
 
 is_deeply($hash_from_plot->{config}, $config, 'JSON dump from plot has config option set');
 

--- a/t/60-serialize_json.t
+++ b/t/60-serialize_json.t
@@ -5,9 +5,10 @@ use warnings;
 use utf8;
 use JSON;
 
-use Test::More tests => 12;
+use Test::More tests => 13;
 
 use Chart::Plotly::Plot;
+use Chart::Plotly::Trace::Scatter;
 
 sub GeneratePlotAndComparePlotAndJSON {
     my $json = shift;
@@ -20,7 +21,7 @@ sub GeneratePlotAndComparePlotAndJSON {
     is_deeply( $perl_hash_from_json->{"layout"}, $plot->layout );
     is_deeply( $perl_hash_from_json->{"config"}, $plot->config );
 
-    is_deeply( $perl_hash_from_json, from_json( $plot->TO_JSON ) )
+    is_deeply( $perl_hash_from_json, $plot->TO_JSON )
       ;    # comparing perl objects to avoid the whitespace management
 }
 
@@ -79,4 +80,17 @@ ENDOFJSON
 ENDOFJSON
 
     GeneratePlotAndComparePlotAndJSON($json_without_layout);
+}
+
+{
+    use PDL;
+    my $plot = Chart::Plotly::Plot->new(
+        traces => [Chart::Plotly::Trace::Scatter->new(x => pdl([0, 1, 2]), y => pdl([0, 1, 2]))]
+    );
+    
+    my $expected_json = {data => [{type => 'scatter', x => [0, 1, 2], y => [0, 1, 2]}]};
+    
+    my $json = JSON->new()->allow_blessed(1)->convert_blessed(1);
+
+    is_deeply($expected_json, $json->decode($plot->to_json_text));
 }


### PR DESCRIPTION
TO_JSON method was returning a string and when used using external serializers wasn't working because the string returned was scaped to be included as a string and not as part of the serialized JSON.